### PR TITLE
Include $diamond::extra_handlers variable in diamond::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,7 @@ class diamond::config {
   $hostname_method   = $diamond::hostname_method
   $handlers_path     = $diamond::handlers_path
   $rotate_days       = $diamond::rotate_days
+  $extra_handlers    = $diamond::extra_handlers
   file { '/etc/diamond/diamond.conf':
     ensure  => present,
     content => template('diamond/etc/diamond/diamond.conf.erb'),


### PR DESCRIPTION
Explicitly pull extra_handlers variable into diamond::config so that the erb template will have them in scope.

Note: This is a copy of eXprojects' PR to garethr's upstream project.
